### PR TITLE
fix: show help when parameters are not empty

### DIFF
--- a/packages/yoga/src/cli/index.ts
+++ b/packages/yoga/src/cli/index.ts
@@ -8,21 +8,16 @@ function run() {
   yargs
     .usage('Usage: $0 <command> [options]')
     .command(
-      'dev',
-      'Start the server in dev mode',
-      // @ts-ignore
-      () => {},
-      () => watch(),
+      'dev', 'Start the server in dev mode', {}, watch
     )
     .command(
       'scaffold',
-      'Scaffold a new GraphQL type',
-      () => {},
-      () => scaffold(),
+      'Scaffold a new GraphQL type', {}, scaffold
     )
-    .help('h')
-    .alias('h', 'help')
-    .version().argv
+    .help()
+    .version()
+    .showHelp()
+    .argv
 }
 
 // Only call run when running from CLI, not when included for tests


### PR DESCRIPTION
## Motivation

Cleanup yargs and introduce good patterns. 
What was done:
- Removed invalid options from help
yargs work with global and command wide help. 
- Launching help by default when `yoga` command is executed.

Moving to modules did not make much sense at the moment. 