### PR TITLE
Support custom env vars and env-specific config

### DIFF
--- a/packages/yoga/package.json
+++ b/packages/yoga/package.json
@@ -21,6 +21,7 @@
     "chokidar": "^2.1.1",
     "create-yoga": "0.0.2",
     "decache": "^4.5.1",
+    "dotenv": "^7.0.0",
     "graphql": "^0.12.0 || ^0.13.0 || ^14.0.0",
     "inquirer": "^6.2.1",
     "js-yaml": "^3.12.1",
@@ -35,6 +36,7 @@
   },
   "devDependencies": {
     "@types/chokidar": "1.7.5",
+    "@types/dotenv": "^6.1.0",
     "@types/express": "4.16.1",
     "@types/graphql": "14.0.7",
     "@types/inquirer": "0.0.44",

--- a/packages/yoga/src/cli/commands/build/index.ts
+++ b/packages/yoga/src/cli/commands/build/index.ts
@@ -17,8 +17,8 @@ const diagnosticHost: ts.FormatDiagnosticsHost = {
   getCanonicalFileName: path => path,
 }
 
-export default () => {
-  const info = importYogaConfig()
+export default (argv: Record<string, string>) => {
+  const info = importYogaConfig({ env: argv.env })
   const config = readConfigFromTsConfig(info)
 
   compile(config.fileNames, config.options)

--- a/packages/yoga/src/cli/commands/eject/index.ts
+++ b/packages/yoga/src/cli/commands/eject/index.ts
@@ -5,8 +5,8 @@ import { writeEjectFiles } from '../build'
 import { relative } from 'path'
 import { resolvePrettierOptions, prettify } from '../../../helpers'
 
-export default async () => {
-  const info = importYogaConfig()
+export default async (argv: Record<string, string>) => {
+  const info = importYogaConfig({ env: argv.env })
   const prettierOptions = await resolvePrettierOptions(info.projectDir)
 
   if (
@@ -23,5 +23,7 @@ export default async () => {
     process.exit(1)
   }
 
-  writeEjectFiles(info, (filePath, content) => writeFileSync(filePath, prettify(content, prettierOptions)))
+  writeEjectFiles(info, (filePath, content) =>
+    writeFileSync(filePath, prettify(content, prettierOptions)),
+  )
 }

--- a/packages/yoga/src/cli/commands/scaffold/index.ts
+++ b/packages/yoga/src/cli/commands/scaffold/index.ts
@@ -9,8 +9,8 @@ import { Config } from '../../../types'
 import { spawnAsync } from '../../spawnAsync'
 import execa = require('execa')
 
-export default async () => {
-  const { yogaConfig, projectDir } = importYogaConfig()
+export default async (argv: Record<string, string>) => {
+  const { yogaConfig, projectDir } = importYogaConfig({ env: argv.env })
   const hasDb = !!yogaConfig.prisma
   const inputTypeQuestion: inquirer.Question<{ inputTypeName: string }> = {
     name: 'inputTypeName',

--- a/packages/yoga/src/cli/commands/start/index.ts
+++ b/packages/yoga/src/cli/commands/start/index.ts
@@ -1,6 +1,6 @@
 import { start } from '../../../server'
 import { importYogaConfig } from '../../../config'
 
-export default async () => {
-  return start(importYogaConfig())
+export default async (argv: Record<string, string>) => {
+  return start(importYogaConfig({ env: argv.env }))
 }

--- a/packages/yoga/src/cli/commands/watch/index.ts
+++ b/packages/yoga/src/cli/commands/watch/index.ts
@@ -1,5 +1,5 @@
 import { watch } from '../../../server'
 
-export default async () => {
-  return watch()
+export default async (args: Record<string, string>) => {
+  return watch(args['env'])
 }

--- a/packages/yoga/src/cli/index.ts
+++ b/packages/yoga/src/cli/index.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 import { createTemplate } from 'create-yoga'
 import * as yargs from 'yargs'
 import build from './commands/build'
@@ -18,9 +17,14 @@ function run() {
     .command('scaffold', 'Scaffold a new GraphQL type', {}, scaffold)
     .command('build', 'Build a yoga server', {}, build)
     .command('eject', 'Eject your project', {}, eject)
-    .alias('h', 'help')
+    .strict(true)
+    .demandCommand()
+    .option('env', {
+      alias: 'e',
+      description: 'Pass a custom NODE_ENV variable',
+    })
     .help('help')
-    .showHelpOnFail(true, 'Specify --help for available options')
+    .showHelpOnFail(true)
     .version().argv
 }
 

--- a/packages/yoga/src/index.ts
+++ b/packages/yoga/src/index.ts
@@ -3,10 +3,13 @@ import { ExpressContext } from 'apollo-server-express/dist/ApolloServer'
 import express from 'express'
 import * as Http from 'http'
 import { InputConfig as YogaConfig, MaybePromise, Yoga } from './types'
+import { injectCustomEnvironmentVariables } from './config'
 
 export * from 'nexus'
 export * from 'nexus-prisma'
 export { ApolloServer, express }
+
+injectCustomEnvironmentVariables()
 
 export function yogaConfig(opts: YogaConfig) {
   return opts

--- a/packages/yoga/src/server.ts
+++ b/packages/yoga/src/server.ts
@@ -31,10 +31,10 @@ register({
   pretty: true,
 })
 
-export async function watch(): Promise<void> {
+export async function watch(env?: string): Promise<void> {
   logger.clearConsole()
   logger.info('Starting development server...')
-  let info = importYogaConfig()
+  let info = importYogaConfig({ env })
   let filesToWatch = [path.join(info.projectDir, '**', '*.ts')]
 
   if (info.prismaClientDir && info.datamodelInfoDir) {
@@ -64,7 +64,7 @@ export async function watch(): Promise<void> {
 
         if (filesToReloadBatched.length === 2) {
           // TODO: Do not invalidate everything, only the necessary stuff
-          info = importYogaConfig({ invalidate: true })
+          info = importYogaConfig({ invalidate: true, env})
           filesToReloadBatched = []
         } else {
           return Promise.resolve(true)


### PR DESCRIPTION
Implements #95

- Support custom env variables with `dotenv`.
	- If no `NODE_ENV` is passed, a `.env` file is searched
	- Otherwise, a `.env.${process.env.NODE_ENV}` file is searched
- Support env-specific config file
	- If no `NODE_ENV` is passed, a `yoga.config.ts` or `yoga.config.dev.ts` file is searched
	- Otherwise, a `yoga.config.${NODE_ENV}.ts` file is searched
- Support custom NODE_ENV through the `yoga` CLI using the `--env` or `-e` option