### PR TITLE
Bind to PORT env variable if available

### DIFF
--- a/packages/yoga/src/server.ts
+++ b/packages/yoga/src/server.ts
@@ -230,9 +230,11 @@ function getYogaServer(info: ConfigWithInfo): Yoga {
       },
       async startServer(express) {
         return new Promise<Server>((resolve, reject) => {
+          const port = process.env.PORT || 4000
+
           const httpServer = express
-            .listen({ port: 4000 }, () => {
-              console.log(`🚀  Server ready at http://localhost:4000/`)
+            .listen({ port }, () => {
+              console.log(`🚀  Server ready at http://localhost:${port}/`)
 
               resolve(httpServer)
             })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below. If PR contains feature please make sure that corresponding issue is created and linked in PR

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

## Description

This makes deploying to Heroku easier by making the server bind to `PORT` environment variable by default (with fallback to port `4000`). Not entirely sure if `PORT` name is the real standard here, but I'm pretty sure it's the most prominent one.

## Progress

- [x] Implementation
- [ ] Documentation 
- [ ] Tests