### PR TITLE
fix: use the new datamodel syntax in with-db example

### DIFF
--- a/examples/with-db/prisma/datamodel.prisma
+++ b/examples/with-db/prisma/datamodel.prisma
@@ -1,14 +1,14 @@
 type User {
-  id: ID! @unique
+  id: ID! @id
   email: String! @unique
   name: String!
   posts: [Post!]!
 }
 
 type Post {
-  id: ID! @unique
+  id: ID! @id
   title: String!
   content: String!
-  published: Boolean! @default(value: "false")
+  published: Boolean! @default(value: false)
   author: User!
 }


### PR DESCRIPTION
## Description
This PR along with #134 allows yoga2 to work with the new Prisma datamodel.